### PR TITLE
Update directory path resolution to respect SNAP_USER_DATA

### DIFF
--- a/src/Infrastructure/BitCrafts.Infrastructure/Extensions/ServiceCollectionExtension.cs
+++ b/src/Infrastructure/BitCrafts.Infrastructure/Extensions/ServiceCollectionExtension.cs
@@ -59,7 +59,10 @@ public static class ServiceCollectionExtension
 
     private static void CreateDirectory(string directory)
     {
-        var directoryPath = Path.Combine(Directory.GetCurrentDirectory(), directory);
+        var basePath = Environment.GetEnvironmentVariable("SNAP_USER_DATA")
+                       ?? AppContext.BaseDirectory;
+
+        var directoryPath = Path.Combine(basePath, directory);
         if (!Directory.Exists(directoryPath))
             Directory.CreateDirectory(Path.GetFullPath(directoryPath));
     }

--- a/src/Infrastructure/BitCrafts.Infrastructure/Modules/ModuleRegistrer.cs
+++ b/src/Infrastructure/BitCrafts.Infrastructure/Modules/ModuleRegistrer.cs
@@ -21,12 +21,12 @@ public sealed class ModuleRegistrer : IModuleRegistrer
 
     public void RegisterModules(IServiceCollection services)
     {
-        var currentPath = Directory.GetCurrentDirectory();
-        var tempPath = Path.Combine(currentPath, "Modules");
-        var modulesPath = Path.IsPathRooted(tempPath) ? tempPath : Path.GetFullPath(tempPath);
+        var basePath = Environment.GetEnvironmentVariable("SNAP_USER_DATA")
+                       ?? AppContext.BaseDirectory;
 
-        LoadModulesFromPath(modulesPath, services);
-        LoadModulesFromPath(currentPath, services);
+        var basePathModules = Path.Combine(basePath, "Modules");
+        LoadModulesFromPath(Path.GetFullPath(basePathModules), services);
+        LoadModulesFromPath(Path.GetFullPath(basePath), services);
     }
 
     public void Dispose()


### PR DESCRIPTION
Modified the directory creation logic to prioritize the `SNAP_USER_DATA` environment variable if available, falling back to `AppContext.BaseDirectory`. This ensures compatibility with environments where `SNAP_USER_DATA` is used.